### PR TITLE
chore: replace brew tap with p6df::core::homebrew::cmd::brew tap

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -38,7 +38,7 @@ p6df::modules::heroku::vscodes() {
 ######################################################################
 p6df::modules::heroku::external::brew() {
 
-  brew tap heroku/brew
+  p6df::core::homebrew::cmd::brew tap heroku/brew
   p6df::core::homebrew::cli::brew::install heroku
 
   p6_return_void


### PR DESCRIPTION
Replace raw brew tap with p6df homebrew wrapper in init.zsh:41

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>