### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -32,11 +32,11 @@ p6df::modules::heroku::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::heroku::external::brew()
+# Function: p6df::modules::heroku::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::heroku::external::brew() {
+p6df::modules::heroku::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap heroku/brew
   p6df::core::homebrew::cli::brew::install heroku


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly