### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::heroku::deps()
-#
-#>
-######################################################################
 p6df::modules::heroku::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-js
@@ -14,27 +8,26 @@ p6df::modules::heroku::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::heroku::vscodes()
-#
-#>
-######################################################################
-p6df::modules::heroku::vscodes() {
+p6df::modules::heroku::completions::init() {
 
-  p6df::modules::vscode::extension::install ivangabriele.vscode-heroku
-  p6df::modules::vscode::extension::install JustBrenny.hero-heroku
-  p6df::modules::vscode::extension::install pkosta2005.heroku-command
+  local _module="$1"
+  local _dir="$2"
+  HEROKU_AC_ZSH_SETUP_PATH=$HOME/Library/Caches/heroku/autocomplete/zsh_setup
+  p6_file_load "$HEROKU_AC_ZSH_SETUP_PATH"
 
   p6_return_void
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::heroku::external::brews()
-#
-#>
+p6df::modules::heroku::aliases::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_alias "heroku" "p6df::modules::heroku::cmd"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::heroku::external::brews() {
 
@@ -44,12 +37,6 @@ p6df::modules::heroku::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::langs()
-#
-#>
 ######################################################################
 p6df::modules::heroku::langs() {
 
@@ -67,6 +54,40 @@ p6df::modules::heroku::langs() {
 }
 
 ######################################################################
+p6df::modules::heroku::vscodes() {
+
+  p6df::modules::vscode::extension::install ivangabriele.vscode-heroku
+  p6df::modules::vscode::extension::install JustBrenny.hero-heroku
+  p6df::modules::vscode::extension::install pkosta2005.heroku-command
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::langs()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::heroku::aliases::init(_module, dir)
@@ -77,33 +98,12 @@ p6df::modules::heroku::langs() {
 #
 #>
 ######################################################################
-p6df::modules::heroku::aliases::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_alias "heroku" "p6df::modules::heroku::cmd"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::heroku::completions::init()
 #
 #  Environment:	 HEROKU_AC_ZSH_SETUP_PATH HOME
 #>
-######################################################################
-p6df::modules::heroku::completions::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  HEROKU_AC_ZSH_SETUP_PATH=$HOME/Library/Caches/heroku/autocomplete/zsh_setup
-  p6_file_load "$HEROKU_AC_ZSH_SETUP_PATH"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::heroku::deps()
+#
+#>
+######################################################################
 p6df::modules::heroku::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-js
@@ -7,6 +13,13 @@ p6df::modules::heroku::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::completions::init()
+#
+#  Environment:	 HEROKU_AC_ZSH_SETUP_PATH HOME
+#>
 ######################################################################
 p6df::modules::heroku::completions::init() {
 
@@ -19,6 +32,16 @@ p6df::modules::heroku::completions::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::heroku::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
+######################################################################
 p6df::modules::heroku::aliases::init() {
   local _module="$1"
   local dir="$2"
@@ -29,6 +52,12 @@ p6df::modules::heroku::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::heroku::external::brews()
+#
+#>
+######################################################################
 p6df::modules::heroku::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap heroku/brew
@@ -37,6 +66,12 @@ p6df::modules::heroku::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::heroku::langs()
+#
+#>
 ######################################################################
 p6df::modules::heroku::langs() {
 
@@ -54,6 +89,12 @@ p6df::modules::heroku::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::heroku::vscodes()
+#
+#>
+######################################################################
 p6df::modules::heroku::vscodes() {
 
   p6df::modules::vscode::extension::install ivangabriele.vscode-heroku
@@ -63,47 +104,6 @@ p6df::modules::heroku::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::heroku::completions::init()
-#
-#  Environment:	 HEROKU_AC_ZSH_SETUP_PATH HOME
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None