### PR TITLE
feat(heroku): add args to completions::init and rename prompt::mod to prompt::context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,16 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::heroku::aliases::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
-- `p6df::modules::heroku::completions::init()`
-- `p6df::modules::heroku::deps()`
-- `p6df::modules::heroku::external::brew()`
-- `p6df::modules::heroku::init(_module, dir)`
+    - _module
+    - dir
+- `p6df::modules::heroku::completions::init(_module, _dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - _dir
+- `p6df::modules::heroku::deps()`
+- `p6df::modules::heroku::external::brews()`
 - `p6df::modules::heroku::langs()`
-- `p6df::modules::heroku::prompt::mod()`
+- `p6df::modules::heroku::prompt::context()`
 - `p6df::modules::heroku::vscodes()`
 
 #### p6df-heroku/lib
@@ -61,13 +60,13 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::heroku::app::set(app)`
   - Args:
-    - app -
+    - app
 
 ##### p6df-heroku/lib/cmd.sh
 
 - `p6df::modules::heroku::cmd(...)`
   - Args:
-    - ... -
+    - ...
 
 ##### p6df-heroku/lib/config.sh
 

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,11 @@ p6df::modules::heroku::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::heroku::completions::init()
+# Function: p6df::modules::heroku::completions::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 HEROKU_AC_ZSH_SETUP_PATH HOME
 #>


### PR DESCRIPTION
**What:** Add `_module`/`_dir` args to `completions::init`, rename `prompt::mod` to `prompt::context`, rename `external::brew` to `external::brews`, clean up arg doc formatting

**Why:** Aligns function signatures with the established naming convention across p6df modules; consistent plural naming for brew installs

**Test plan:** Source the module and verify `p6df::modules::heroku::completions::init` and `p6df::modules::heroku::prompt::context` work correctly

**Dependencies:** none